### PR TITLE
Add Missing `os` Package Import  

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-
+"os"
 	"strconv"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"


### PR DESCRIPTION
This pull request addresses an issue where the `os` package was not imported, which may lead to errors when functionalities from the `os` package are required in the code.

#### Key Changes:
1. **Added Missing Import**:  
   - The `os` package has been included in the list of imports to ensure compatibility and prevent runtime errors.

#### Benefits:
- Resolves potential issues caused by the absence of the `os` package.
- Ensures the code is ready for any operations that depend on the `os` package.

This minor update ensures smoother execution and enhances code stability.